### PR TITLE
Blocking api

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ event_source.add_event_listener("error", |error| {
 
 ```
 
+In case you prefer a blocking api:
+
+```rust
+extern crate sse_client;
+use sse_client::EventSource;
+
+let event_source = EventSource::new("http://event-stream-address/sub").unwrap();
+
+for event in event_source.receiver().iter() {
+    println!("New Message: {}", event.data);
+}
+```
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ To know more about SSE: [Standard](https://html.spec.whatwg.org/multipage/server
 
 # Example:
 
+Usage:
+
 ```rust
 extern crate sse_client;
 use sse_client::EventSource;
@@ -26,7 +28,7 @@ event_source.add_event_listener("error", |error| {
 
 ```
 
-In case you prefer a blocking api:
+Or:
 
 ```rust
 extern crate sse_client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,20 @@
 //! });
 //!
 //! ```
+//!
+//! Or:
+//! ```no_run
+//! extern crate sse_client;
+//! use sse_client::EventSource;
+//!
+//!
+//! let event_source = EventSource::new("http://event-stream-address/sub").unwrap();
+//!
+//! for event in event_source.receiver().iter() {
+//!     println!("New Message: {}", event.data);
+//! }
+//!
+//! ```
 extern crate url;
 
 mod network;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,6 +184,30 @@ impl EventSource {
         self.stream.lock().unwrap().state()
     }
 
+    /// Returns a receiver that is triggered on any new message or error.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # extern crate sse_client;
+    /// # use sse_client::EventSource;
+    /// let event_source = EventSource::new("http://example.com/sub").unwrap();
+    ///
+    /// for event in event_source.receiver().iter() {
+    ///     println!("New Message: {}", event.data);
+    /// }
+    ///
+    /// ```
+    /// ```no_run
+    /// # extern crate sse_client;
+    /// # use sse_client::EventSource;
+    /// let event_source = EventSource::new("http://example.com/sub").unwrap();
+    /// let rx = event_source.receiver();
+    ///
+    /// let event = rx.recv().unwrap();
+    /// //...
+    ///
+    /// ```
     pub fn receiver(&self) -> mpsc::Receiver<Event> {
         let (tx, rx) = mpsc::channel();
         let error_tx = tx.clone();


### PR DESCRIPTION
```rust
let event_source = EventSource::new("http://event-stream-address/sub").unwrap();

for event in event_source.receiver().iter() {
    println!("New Message: {}", event.data);
}
```