### PR TITLE
Add HTTPS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sse-client"
-version = "1.0.2"
+version = "1.1.0"
 authors = ["Vinicius Gerevini <viniciusgerevini@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -8,8 +8,14 @@ repository = "https://github.com/viniciusgerevini/sse-client"
 description = "Client for streams of Server-Sent Events"
 keywords = ["sse", "server-sent", "events", "event-source"]
 
+[features]
+default = []
+native-tls = ["native-tls-crate"]
+native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
+
 [dependencies]
 url = "1.7.0"
+native-tls-crate = { package = "native-tls", version = "0.2.3", optional = true }
 
 [dev-dependencies]
 http-test-server = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ for event in event_source.receiver().iter() {
     println!("New Message: {}", event.data);
 }
 ```
+## Cargo features
+
+* `native-tls` enables support for HTTPS URLs using [native-tls](https://crates.io/crates/native-tls)
+* `native-tls-vendored` will additionally link OpenSSL statically
+
 ## License
 
 Licensed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,14 @@
 //! ```
 extern crate url;
 
+#[cfg(feature = "native-tls")]
+extern crate native_tls_crate as native_tls;
+
 #[cfg(test)]
 extern crate http_test_server;
 
+#[cfg(feature = "native-tls")]
+mod tls;
 mod network;
 mod pub_sub;
 mod data;

--- a/src/network.rs
+++ b/src/network.rs
@@ -7,10 +7,17 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::io::BufReader;
 use std::time::Duration;
+#[cfg(feature = "native-tls")]
+use crate::tls::MaybeTlsStream;
+
+#[cfg(feature = "native-tls")]
+type InnerStream = MaybeTlsStream;
+#[cfg(not(feature = "native-tls"))]
+type InnerStream = TcpStream;
 
 type Callback = Arc<Mutex<Option<Box<dyn Fn(String) + Send>>>>;
 type CallbackNoArgs = Arc<Mutex<Option<Box<dyn Fn() + Send>>>>;
-type StreamWrapper = Arc<Mutex<Option<TcpStream>>>;
+type StreamWrapper = Arc<Mutex<Option<InnerStream>>>;
 type StateWrapper = Arc<Mutex<State>>;
 type LastIdWrapper = Arc<Mutex<Option<String>>>;
 
@@ -79,7 +86,7 @@ impl EventStream {
     pub fn close(&self) {
         let mut state = self.state.lock().unwrap();
         *state = State::Closed;
-        if let Some(ref st) = *self.stream.lock().unwrap() {
+        if let Some(ref mut st) = *self.stream.lock().unwrap() {
             st.shutdown(Shutdown::Both).unwrap();
         }
     }
@@ -122,8 +129,8 @@ fn listen_stream(
     last_event_id: LastIdWrapper
 ) {
     thread::spawn(move || {
-        let action = match connect_event_stream(&connection_url, &stream, &last_event_id) {
-            Ok(stream) => read_stream(stream, &state, &on_open, &on_message, &failed_attempts),
+        let action = match connect_event_stream(&connection_url, &last_event_id) {
+            Ok(stream) => read_stream(&stream, &state, &on_open, &on_message, &failed_attempts).map(|_| stream),
             Err(error) => Err(StreamAction::Reconnect(error.to_string()))
         };
 
@@ -157,20 +164,29 @@ fn listen_stream(
     });
 }
 
-fn connect_event_stream(url: &Url, stream: &StreamWrapper, last_event_id: &LastIdWrapper) -> Result<TcpStream, Error> {
+fn connect_event_stream(url: &Url, last_event_id: &LastIdWrapper) -> Result<InnerStream, Error> {
     let connection_stream = event_stream_handshake(url, last_event_id)?;
-    let mut stream = stream.lock().unwrap();
-    *stream = Some(connection_stream.try_clone().unwrap());
-
     Ok(connection_stream)
 }
 
-fn event_stream_handshake(url: &Url, last_event_id: &LastIdWrapper) -> Result<TcpStream, Error> {
+fn event_stream_handshake(url: &Url, last_event_id: &LastIdWrapper) -> Result<InnerStream, Error> {
     let path = url.path();
     let host = get_host(&url);
     let host = host.as_str();
 
+    #[cfg(feature = "native-tls")]
+    let mut stream = {
+        let plain = TcpStream::connect(host)?;
+        if url.scheme() == "https" {
+            MaybeTlsStream::try_wrap_tls(plain, url.host_str().unwrap_or("localhost"))?
+        } else {
+            MaybeTlsStream::wrap_plain(plain)
+        }
+    };
+
+    #[cfg(not(feature = "native-tls"))]
     let mut stream = TcpStream::connect(host)?;
+
     stream.set_read_timeout(Some(Duration::from_millis(60000)))?;
 
     let extra_headers = match *(last_event_id.lock().unwrap()) {
@@ -205,7 +221,7 @@ fn get_host(url: &Url) -> String {
 }
 
 fn read_stream(
-    connection_stream: TcpStream,
+    connection_stream: &InnerStream,
     state: &StateWrapper,
     on_open: &CallbackNoArgs,
     on_message: &Callback,

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,5 +1,5 @@
 use native_tls::{TlsConnector, TlsStream};
-use std::net::{Shutdown, TcpStream};
+use std::net::TcpStream;
 use std::io::{self, Result};
 use std::time::Duration;
 use std::sync::Arc;
@@ -30,10 +30,10 @@ impl MaybeTlsStream {
         }
     }
 
-    pub(crate) fn shutdown(&mut self, how: Shutdown) -> Result<()> {
+    pub(crate) fn clone_plain_handle(&self) -> Result<TcpStream> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().shutdown(),
-            Self::Plain(inner) => inner.lock().unwrap().shutdown(how),
+            Self::Tls(inner) => inner.lock().unwrap().get_ref().try_clone(),
+            Self::Plain(inner) => inner.lock().unwrap().try_clone(),
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -2,72 +2,63 @@ use native_tls::{TlsConnector, TlsStream};
 use std::net::TcpStream;
 use std::io::{self, Result};
 use std::time::Duration;
-use std::sync::Arc;
-use std::sync::Mutex;
-
-type StreamWrapper<T> = Arc<Mutex<T>>;
 
 pub(crate) enum MaybeTlsStream {
-    Tls(StreamWrapper<TlsStream<TcpStream>>),
-    Plain(StreamWrapper<TcpStream>),
+    Tls(TlsStream<TcpStream>),
+    Plain(TcpStream),
 }
 
 impl MaybeTlsStream {
     pub(crate) fn try_wrap_tls(plain: TcpStream, sni: &str) -> Result<MaybeTlsStream> {
         let connector = TlsConnector::new().unwrap();
         let stream = connector.connect(sni, plain).map_err(|_| io::Error::from(io::ErrorKind::Other))?;
-        Ok(Self::Tls(Arc::new(Mutex::new(stream))))
+        Ok(Self::Tls(stream))
     }
 
+    #[inline]
     pub(crate) fn wrap_plain(plain: TcpStream) -> MaybeTlsStream {
-        Self::Plain(Arc::new(Mutex::new(plain)))
+        Self::Plain(plain)
     }
 
     pub(crate) fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().get_ref().set_read_timeout(dur),
-            Self::Plain(inner) => inner.lock().unwrap().set_read_timeout(dur),
+            Self::Tls(inner) => inner.get_ref().set_read_timeout(dur),
+            Self::Plain(inner) => inner.set_read_timeout(dur),
         }
     }
 
     pub(crate) fn clone_plain_handle(&self) -> Result<TcpStream> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().get_ref().try_clone(),
-            Self::Plain(inner) => inner.lock().unwrap().try_clone(),
+            Self::Tls(inner) => inner.get_ref().try_clone(),
+            Self::Plain(inner) => inner.try_clone(),
         }
     }
 }
 
 impl io::Read for MaybeTlsStream {
+    #[inline]
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().read(buf),
-            Self::Plain(inner) => inner.lock().unwrap().read(buf),
-        }
-    }
-}
-
-impl io::Read for &MaybeTlsStream {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        match self {
-            MaybeTlsStream::Tls(inner) => inner.lock().unwrap().read(buf),
-            MaybeTlsStream::Plain(inner) => inner.lock().unwrap().read(buf),
+            Self::Tls(inner) => inner.read(buf),
+            Self::Plain(inner) => inner.read(buf),
         }
     }
 }
 
 impl io::Write for MaybeTlsStream {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().write(buf),
-            Self::Plain(inner) => inner.lock().unwrap().write(buf),
+            Self::Tls(inner) => inner.write(buf),
+            Self::Plain(inner) => inner.write(buf),
         }
     }
 
+    #[inline]
     fn flush(&mut self) -> Result<()> {
         match self {
-            Self::Tls(inner) => inner.lock().unwrap().flush(),
-            Self::Plain(inner) => inner.lock().unwrap().flush(),
+            Self::Tls(inner) => inner.flush(),
+            Self::Plain(inner) => inner.flush(),
         }
     }
 }

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -1,0 +1,73 @@
+use native_tls::{TlsConnector, TlsStream};
+use std::net::{Shutdown, TcpStream};
+use std::io::{self, Result};
+use std::time::Duration;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+type StreamWrapper<T> = Arc<Mutex<T>>;
+
+pub(crate) enum MaybeTlsStream {
+    Tls(StreamWrapper<TlsStream<TcpStream>>),
+    Plain(StreamWrapper<TcpStream>),
+}
+
+impl MaybeTlsStream {
+    pub(crate) fn try_wrap_tls(plain: TcpStream, sni: &str) -> Result<MaybeTlsStream> {
+        let connector = TlsConnector::new().unwrap();
+        let stream = connector.connect(sni, plain).map_err(|_| io::Error::from(io::ErrorKind::Other))?;
+        Ok(Self::Tls(Arc::new(Mutex::new(stream))))
+    }
+
+    pub(crate) fn wrap_plain(plain: TcpStream) -> MaybeTlsStream {
+        Self::Plain(Arc::new(Mutex::new(plain)))
+    }
+
+    pub(crate) fn set_read_timeout(&self, dur: Option<Duration>) -> Result<()> {
+        match self {
+            Self::Tls(inner) => inner.lock().unwrap().get_ref().set_read_timeout(dur),
+            Self::Plain(inner) => inner.lock().unwrap().set_read_timeout(dur),
+        }
+    }
+
+    pub(crate) fn shutdown(&mut self, how: Shutdown) -> Result<()> {
+        match self {
+            Self::Tls(inner) => inner.lock().unwrap().shutdown(),
+            Self::Plain(inner) => inner.lock().unwrap().shutdown(how),
+        }
+    }
+}
+
+impl io::Read for MaybeTlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self {
+            Self::Tls(inner) => inner.lock().unwrap().read(buf),
+            Self::Plain(inner) => inner.lock().unwrap().read(buf),
+        }
+    }
+}
+
+impl io::Read for &MaybeTlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self {
+            MaybeTlsStream::Tls(inner) => inner.lock().unwrap().read(buf),
+            MaybeTlsStream::Plain(inner) => inner.lock().unwrap().read(buf),
+        }
+    }
+}
+
+impl io::Write for MaybeTlsStream {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        match self {
+            Self::Tls(inner) => inner.lock().unwrap().write(buf),
+            Self::Plain(inner) => inner.lock().unwrap().write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        match self {
+            Self::Tls(inner) => inner.lock().unwrap().flush(),
+            Self::Plain(inner) => inner.lock().unwrap().flush(),
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds optional support for HTTPS URLs.

The public API of the library remains unchanged, and unless the `native-tls` feature is enabled the internals work more or less as before as well.