### PR TITLE
Fix missing bound check in status line validation

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -305,6 +305,9 @@ fn validate_content_type(line: String) -> Result<(), StreamAction> {
 }
 
 fn validate_status_code(line: String) -> Result<i32, StreamAction> {
+    if line.len() <= 9 {
+        return Err(StreamAction::Close(String::from("Invalid status line")));
+    }
     let status = &line[9..].trim_end();
     let status_code: i32 = status[..3].parse().unwrap();
 


### PR DESCRIPTION
Currently, the status code validation can fail if the status line just happens to be too short (either because of a badly written server or some interruption). When that happens, you get a panic as there's a spot where the code indexes directly into a string. This PR adds a length check so we get an explicit error.