### PR TITLE
Some refacts in different aspects.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/src/data.rs
+++ b/src/data.rs
@@ -108,7 +108,10 @@ impl EventBuilder {
 
         match parse_field(message) {
             ("event", value) => pending_event.event = Some(value.to_string()),
-            ("data", value) => pending_event.data = Some(value.to_string()),
+            ("data", value) => pending_event.data = match pending_event.data {
+                Some(ref old_data) => Some(format!("{}\n{}", old_data, value)),
+                None => Some(value.to_string())
+            },
             ("id", value) => pending_event.id = Some(value.to_string()),
             ("retry", value) => pending_event.retry = Some(value.to_string()),
             _ => {}

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,12 +5,14 @@ pub struct EventBuilder {
 /// Event data sent by server
 #[derive(Debug, PartialEq, Clone)]
 pub struct Event {
-    /// Represents message `id` field. Default "".
-    pub id: String,
-    /// Represents message `event` field. Default "message".
-    pub type_: String,
-    /// Represents message `data` field. Default "".
-    pub data: String
+    /// Represents message `event` field.
+    pub event: Option<String>,
+    /// Represents message `data` field.
+    pub data: Option<String>,
+    /// Represents message `id` field.
+    pub id: Option<String>,
+    /// Represents message `retry` field.
+    pub retry: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -21,8 +23,55 @@ pub enum EventBuilderState {
 }
 
 impl Event {
-    pub fn new(type_: &str, data: &str) -> Event {
-        Event { id: String::from(""), type_: String::from(type_), data: String::from(data) }
+    pub fn new() -> Event {
+        Event {
+            event: None,
+            data: None,
+            id: None,
+            retry: None,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct EventData {
+    event: Option<String>,
+    data: Option<String>,
+    id: Option<String>,
+    retry: Option<String>,
+}
+
+impl EventData {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn event(mut self, event: impl Into<String>) -> Self {
+        self.event = Some(event.into());
+        self
+    }
+
+    pub fn data(mut self, data: impl Into<String>) -> Self {
+        self.data = Some(data.into());
+        self
+    }
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    pub fn retry(mut self, retry: impl Into<String>) -> Self {
+        self.retry = Some(retry.into());
+        self
+    }
+
+    pub fn build(self) -> Event {
+        Event {
+            event: self.event,
+            data: self.data,
+            id: self.id,
+            retry: self.retry,
+        }
     }
 }
 
@@ -52,13 +101,16 @@ impl EventBuilder {
     fn update_event(&mut self, message: &str) -> EventBuilderState {
         let mut pending_event = match &self.pending_event {
             EventBuilderState::Pending(ref e) => e.clone(),
-            _ => Event::new("message", "")
+            _ => EventData::new()
+                .event("message")
+                .build(),
         };
 
         match parse_field(message) {
-            ("data", value) => pending_event.data = String::from(value),
-            ("event", value) => pending_event.type_ = String::from(value),
-            ("id", value) => pending_event.id = String::from(value),
+            ("event", value) => pending_event.event = Some(value.to_string()),
+            ("data", value) => pending_event.data = Some(value.to_string()),
+            ("id", value) => pending_event.id = Some(value.to_string()),
+            ("retry", value) => pending_event.retry = Some(value.to_string()),
             _ => {}
         }
 
@@ -66,7 +118,7 @@ impl EventBuilder {
     }
 
     pub fn clear(&mut self) {
-        self.pending_event =  EventBuilderState::Empty;
+        self.pending_event = EventBuilderState::Empty;
     }
 
     pub fn get_event(&self) -> EventBuilderState {
@@ -96,7 +148,7 @@ mod tests {
         e.update("data: test");
 
         if let EventBuilderState::Pending(event) = e.get_event() {
-            assert_eq!(event.type_, String::from("message"));
+            assert_eq!(event.event, Some("message".to_string()));
         } else {
             panic!("event should be pending");
         }
@@ -109,7 +161,7 @@ mod tests {
         e.update("");
 
         if let EventBuilderState::Complete(event) = e.get_event() {
-            assert_eq!(event.data, String::from("test"));
+            assert_eq!(event.data, Some("test".to_string()));
         } else {
             panic!("event should be complete");
         }
@@ -129,7 +181,7 @@ mod tests {
         e.update("data: test");
 
         if let EventBuilderState::Pending(event) = e.get_event() {
-            assert_eq!(event.data, String::from("test"));
+            assert_eq!(event.data, Some("test".to_string()));
         } else {
             panic!("event should be pending");
         }
@@ -141,7 +193,7 @@ mod tests {
         e.update("event: some_event");
 
         if let EventBuilderState::Pending(event) = e.get_event() {
-            assert_eq!(event.type_, String::from("some_event"));
+            assert_eq!(event.event, Some("some_event".to_string()));
         } else {
             panic!("event should be pending");
         }
@@ -153,7 +205,7 @@ mod tests {
         e.update("id: 123abc");
 
         if let EventBuilderState::Pending(event) = e.get_event() {
-            assert_eq!(event.id, String::from("123abc"));
+            assert_eq!(event.id, Some("123abc".to_string()));
         } else {
             panic!("event should be pending");
         }
@@ -161,7 +213,10 @@ mod tests {
 
     #[test]
     fn should_incrementally_fill_event_fields() {
-        let expected_event = Event::new("some_event", "test");
+        let expected_event = EventData::new()
+            .event("some_event")
+            .data("test")
+            .build();
         let mut e = EventBuilder::new();
         e.update("event: some_event");
         e.update("data: test");
@@ -186,7 +241,10 @@ mod tests {
 
     #[test]
     fn should_start_clean_event_after_previous_is_completed() {
-        let expected_event = Event::new("message", "test2");
+        let expected_event = EventData::new()
+            .event("message")
+            .data("test2")
+            .build();
         let mut e = EventBuilder::new();
 
         e.update("event: some_event");
@@ -203,7 +261,10 @@ mod tests {
 
     #[test]
     fn should_ignore_updates_started_with_colon() {
-        let expected_event = Event::new("some_event", "test");
+        let expected_event = EventData::new()
+            .event("some_event")
+            .data("test")
+            .build();
         let mut e = EventBuilder::new();
 
         e.update("event: some_event");
@@ -226,7 +287,10 @@ mod tests {
 
     #[test]
     fn should_parse_messages_even_with_colons() {
-        let expected_event = Event::new("some:id:with:colons", "some:data:with:colons");
+        let expected_event = EventData::new()
+            .event("some:id:with:colons")
+            .data("some:data:with:colons")
+            .build();
         let mut e = EventBuilder::new();
 
         e.update("event: some:id:with:colons");
@@ -252,7 +316,10 @@ mod tests {
 
     #[test]
     fn should_ignore_messages_without_colon() {
-        let expected_event = Event::new("some_event", "test");
+        let expected_event = EventData::new()
+            .event("some_event")
+            .data("test")
+            .build();
         let mut e = EventBuilder::new();
 
         e.update("event: some_event");

--- a/src/data.rs
+++ b/src/data.rs
@@ -83,7 +83,7 @@ impl EventBuilder {
     pub fn update(&mut self, message: &str) -> EventBuilderState {
         if message == "" {
             self.finalize_event();
-        } else if !message.starts_with(":") && message.contains(":") {
+        } else if !message.starts_with(":") {
             self.pending_event = self.update_event(message);
         }
 
@@ -131,7 +131,14 @@ impl EventBuilder {
 
 fn parse_field<'a>(message: &'a str) -> (&'a str, &'a str) {
     let parts: Vec<&str> = message.splitn(2, ":").collect();
-    (parts[0], parts[1].trim())
+    if parts.len() < 2 {
+        return (parts[0], "");
+    }
+    if parts[1].starts_with(" ") {
+        (parts[0], &parts[1][1..])
+    } else {
+        (parts[0], parts[1])
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! let event_source = EventSource::new("http://event-stream-address/sub").unwrap();
 //!
 //! for event in event_source.receiver().iter() {
-//!     println!("New Message: {}", event.data);
+//!     println!("New Message: {:?}", event.data);
 //! }
 //!
 //! ```
@@ -56,7 +56,7 @@ use network::EventStream;
 use pub_sub::Bus;
 use data::{EventBuilder, EventBuilderState};
 
-pub use data::Event;
+pub use data::{Event, EventData};
 pub use network::State;
 
 
@@ -92,8 +92,11 @@ impl EventSource {
         let event_bus = Arc::clone(&bus);
         event_stream.on_error(move |message| {
             let event_bus = event_bus.lock().unwrap();
-            let event = Event::new("error", &message);
-            event_bus.publish(event.type_.clone(), event);
+            let event = EventData::new()
+                .event("error")
+                .data(message)
+                .build();
+            event_bus.publish("error".to_string(), event);
         });
 
         let event_builder = Arc::new(Mutex::new(EventBuilder::new()));
@@ -148,7 +151,7 @@ impl EventSource {
     /// let event_source = EventSource::new("http://example.com/sub").unwrap();
     ///
     /// event_source.on_message(|message| {
-    ///     println!("Message received: {}", message.data);
+    ///     println!("Message received: {:?}", message.data);
     /// });
     /// ```
     pub fn on_message<F>(&self, listener: F) where F: Fn(Event) + Send + 'static {
@@ -170,16 +173,16 @@ impl EventSource {
     ///
     ///
     /// event_source.add_event_listener("myEvent", |event| {
-    ///     println!("Event {} received: {}", event.type_, event.data);
+    ///     println!("Event {:?} received: {:?}", event.event, event.data);
     /// });
     ///
     /// event_source.add_event_listener("error", |error| {
-    ///     println!("Error: {}", error.data);
+    ///     println!("Error: {:?}", error.data);
     /// });
     ///
     /// // equivalent to `on_message`
     /// event_source.add_event_listener("message", |message| {
-    ///     println!("Message received: {}", message.data);
+    ///     println!("Message received: {:?}", message.data);
     /// });
     /// ```
     pub fn add_event_listener<F>(&self, event_type: &str, listener: F) where F: Fn(Event) + Send + 'static {
@@ -214,7 +217,7 @@ impl EventSource {
     /// let event_source = EventSource::new("http://example.com/sub").unwrap();
     ///
     /// for event in event_source.receiver().iter() {
-    ///     println!("New Message: {}", event.data);
+    ///     println!("New Message: {:?}", event.data);
     /// }
     ///
     /// ```
@@ -246,8 +249,10 @@ impl EventSource {
 
 fn publish_initial_stream_event(event_bus: &Arc<Mutex<Bus<Event>>>) {
     let event_bus = event_bus.lock().unwrap();
-    let event = Event::new("stream_opened", "");
-    event_bus.publish(event.type_.clone(), event);
+    let event = EventData::new()
+        .event("stream_opened")
+        .build();
+    event_bus.publish("stream_opened".to_string(), event);
 }
 
 fn handle_message(
@@ -260,8 +265,12 @@ fn handle_message(
 
     if let EventBuilderState::Complete(event) = event_builder.update(&message) {
         let event_bus = event_bus.lock().unwrap();
-        event_stream.lock().unwrap().set_last_id(event.id.clone());
-        event_bus.publish(event.type_.clone(), event);
+        if let Some(id) = event.id.as_ref() {
+            event_stream.lock().unwrap().set_last_id(id.clone());
+        }
+        if let Some(e) = event.event.as_ref() {
+            event_bus.publish(e.clone(), event);
+        }
         event_builder.clear();
     }
 }
@@ -319,7 +328,7 @@ mod tests {
             .send_line("data: some message").send_line("");
 
         let message = rx.recv().unwrap();
-        assert_eq!(message, "some message");
+        assert_eq!(message, Some("some message".to_string()));
 
         event_source.close();
     }
@@ -348,8 +357,8 @@ mod tests {
         let message = rx.recv().unwrap();
         let message2 = rx.recv().unwrap();
 
-        assert_eq!(message, "some message");
-        assert_eq!(message2, "some message");
+        assert_eq!(message, Some("some message".to_string()));
+        assert_eq!(message2, Some("some message".to_string()));
 
         event_source.close();
     }
@@ -380,8 +389,8 @@ mod tests {
         let message = rx.recv().unwrap();
         let message2 = rx.recv().unwrap();
 
-        assert_eq!(message, "message");
-        assert_eq!(message2, "this is a message");
+        assert_eq!(message, Some("message".to_string()));
+        assert_eq!(message2, Some("this is a message".to_string()));
 
         event_source.close();
     }
@@ -411,8 +420,8 @@ mod tests {
         let message = rx.recv().unwrap();
         let message2 = rx.recv().unwrap();
 
-        assert_eq!(message, "message");
-        assert_eq!(message2, "this is a message");
+        assert_eq!(message, Some("message".to_string()));
+        assert_eq!(message2, Some("this is a message".to_string()));
 
         event_source.close();
     }
@@ -437,8 +446,8 @@ mod tests {
 
         let message = rx.recv().unwrap();
 
-        assert_eq!(message.type_, String::from("myEvent"));
-        assert_eq!(message.data, String::from("my message"));
+        assert_eq!(message.event, Some("myEvent".to_string()));
+        assert_eq!(message.data, Some("my message".to_string()));
 
         event_source.close();
     }
@@ -557,8 +566,8 @@ mod tests {
         stream_endpoint.send("data: some message\n\n");
         stream_endpoint.send("data: some message 2\n\n");
 
-        assert_eq!(rx.recv().unwrap().data, "some message");
-        assert_eq!(rx.recv().unwrap().data, "some message 2");
+        assert_eq!(rx.recv().unwrap().data, Some("some message".to_string()));
+        assert_eq!(rx.recv().unwrap().data, Some("some message 2".to_string()));
 
         event_source.close();
     }
@@ -572,7 +581,7 @@ mod tests {
         let event_source = EventSource::new(&address).unwrap();
         let rx = event_source.receiver();
 
-        assert_eq!(rx.recv().unwrap().type_, "error");
+        assert_eq!(rx.recv().unwrap().event, Some("error".to_string()));
 
         event_source.close();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,4 +585,20 @@ mod tests {
 
         event_source.close();
     }
+
+    #[test]
+    fn should_receive_multiple_data() {
+        let (_server, stream_endpoint, address) = setup();
+        let event_source = EventSource::new(&address).unwrap();
+        thread::sleep(Duration::from_millis(100));
+        let rx = event_source.receiver();
+
+        stream_endpoint.send("data: YHOO\n");
+        stream_endpoint.send("data: +2\n");
+        stream_endpoint.send("data: 10\n\n");
+
+        assert_eq!(rx.recv().unwrap().data, Some("YHOO\n+2\n10".to_string()));
+
+        event_source.close();
+    }
 }


### PR DESCRIPTION
* Create rust.yml
  *  Run the general GitHub Action for Rust
* refact: Refine the Event struct, and use EventData to build Event.
  * Add the missing `retry` field, rename `type_` field back to `event` field, and use `Option<String>` instead of `String` to comply the Rust idioms.
* refact: Concat multiple data with newline separator.
  * Follow the example in [9.2.6 Interpreting an event stream](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) to deal with newlines.
* refact: Deal with whitespace characters special cases.
  * Follow the examples in [9.2.6 Interpreting an event stream](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) to deal with whitespace characters.
